### PR TITLE
Have the P4 Source Provider check for `clean`

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -2423,9 +2423,11 @@ function getSource(settings) {
             yield io.mkdirP(settings.repositoryPath);
             core.endGroup();
         }
-        core.startGroup('Restoring checkout directory');
-        yield p4.revert(`//${clientName}/...`);
-        core.endGroup();
+        if (settings.clean) {
+            core.startGroup('Restoring checkout directory');
+            yield p4.revert(`//${clientName}/...`);
+            core.endGroup();
+        }
         core.startGroup('Checking out the ref');
         yield p4.sync(`//${clientName}/...${settings.ref}`);
         core.endGroup();

--- a/src/p4-source-provider.ts
+++ b/src/p4-source-provider.ts
@@ -138,9 +138,11 @@ export async function getSource(settings: IPerforceSourceSettings): Promise<void
     core.endGroup()
   }
 
-  core.startGroup('Restoring checkout directory')
-  await p4.revert(`//${clientName}/...`)
-  core.endGroup()
+  if (settings.clean) {
+    core.startGroup('Restoring checkout directory')
+    await p4.revert(`//${clientName}/...`)
+    core.endGroup()
+  }
 
   core.startGroup('Checking out the ref')
   await p4.sync(`//${clientName}/...${settings.ref}`)


### PR DESCRIPTION
This change augments `p4-source-provider.js` to check for the `clean` flag in `IGitSourceSettings`. 

This is so clones of larger/slower Perforce repositories take less time during the build phase of Ancestors.